### PR TITLE
operationのmethodにpatternを設定

### DIFF
--- a/models/roboOperation.json
+++ b/models/roboOperation.json
@@ -11,5 +11,6 @@
     {
       "$ref": "./robotOperation/rideOperation.json"
     }
-  ]
+  ],
+  "examples": []
 }

--- a/models/robotOperation/cancelOperation.json
+++ b/models/robotOperation/cancelOperation.json
@@ -3,6 +3,15 @@
   "allOf": [
     {
       "$ref": "./operationMethod.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string",
+          "pattern": "cancel"
+        }
+      }
     }
   ]
 }

--- a/models/robotOperation/moveOperation.json
+++ b/models/robotOperation/moveOperation.json
@@ -7,6 +7,10 @@
     {
       "type": "object",
       "properties": {
+        "method": {
+          "type": "string",
+          "pattern": "move"
+        },
         "argment": {
           "type": "array",
           "items": {

--- a/models/robotOperation/operationMethod.json
+++ b/models/robotOperation/operationMethod.json
@@ -16,5 +16,8 @@
         "$ref": "../common/idObject.v1.json"
       }
     }
-  }
+  },
+  "required": [
+    "method"
+  ]
 }

--- a/models/robotOperation/rideOperation.json
+++ b/models/robotOperation/rideOperation.json
@@ -7,6 +7,10 @@
     {
       "type": "object",
       "properties": {
+        "method": {
+          "type": "string",
+          "pattern": "ride"
+        },
         "argment": {
           "type": "object",
           "properties": {


### PR DESCRIPTION
`oneof` でunionされるModelは、与えられた値から型を一意に推論できなければならない。
https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/

Sampleで作っている、`move`, `cancel`, `ride` の型を見るとき、`cancel`の型は、`move`にも`cancel`にも当てはまる。

例）
moveOperation型
```
{
  method: string,
  robotSpecifications: {
    id: string
  },
  argment: Array[
    {
      floor: integer,
      point: {
        x: integer,
        y: integer,
        z: integer
      }
    }
  ]
}
```

cancelOperation 型
```
{
  method: string,
  robotSpecifications: {
    id: string
  }
}
```

与えられた値
```
{
  method: "move",
  robotSpecifications: {
    id: "000000000000001"
  },
  argment : [
    {
      floor: 1,
      point: {
        x: 0,
        y: 0,
        z: 0
      }
    }
  ]
}
```

上記値の時、moveOperation型にもcancelOperation型にも当てはまってしまう（cancelOperation型と部分一致してしまう）
これは、`oneof` の仕様として正しくない。

これを解消するためには、全ての型が（部分も）一致しない型の`oneof`構成にするか、
(robotOperationの場合は) `method` に `pattern` を設定する。

今回は、`method` に `pattern` を設定した。
（よくある例なら、`type` に何らかのdiscriminatorを設定してもいいかもしれない。）

OASの `pattern` は、そのpropertyに`pattern`で指定した値しか入らない事を示す。

`moveOperation`は、method の`pattern`: `move`
`cancelOperation`は、method の`pattern`: `cancel`
`rideOperation`は、method の`pattern`: `ride`
を記述する事で、それぞれの`method` に設定される文字が決定し、値から型を判定する時の材料にもなる。